### PR TITLE
Fixed issues with transparency masks

### DIFF
--- a/generator.py
+++ b/generator.py
@@ -39,9 +39,9 @@ class NFTGenerator:
             new_img = None
             for p in parts:
                 if type(p) is list:
-                    tmp = Image.open(p[i])
+                    tmp = Image.open(p[i]).convert("RGBA")
                 else:
-                    tmp = Image.open(p)
+                    tmp = Image.open(p).convert("RGBA")
                 if new_img is None:
                     new_img = tmp
                 else:


### PR DESCRIPTION
By converting the image to RGBA before merging, the following issue that I was getting was fixed:
  File "/usr/local/lib/python3.9/site-packages/PIL/Image.py", line 1504, in paste
    self.im.paste(im, box, mask.im)
ValueError: bad transparency mask